### PR TITLE
Link to the updated extension

### DIFF
--- a/livereload.com/_articles/browser/extensions.md
+++ b/livereload.com/_articles/browser/extensions.md
@@ -14,7 +14,7 @@ Download and open to install:
 
 * [Chrome extension on the Chrome Web Store](https://chrome.google.com/webstore/detail/livereload/jnihajbhpnppcggbcgedagnkighmdlei) — **if you want to use it with local files,** be sure to enable “Allow access to file URLs” checkbox in Tools &gt; Extensions &gt; LiveReload after installation.
 
-* [Firefox extension 2.1.0](https://addons.mozilla.org/en-US/firefox/addon/livereload/) from addons.mozilla.org.
+* [Firefox extension](https://addons.mozilla.org/en-US/firefox/addon/livereload-web-extension/) from addons.mozilla.org.
 
 Extensions will be updated automatically.
 


### PR DESCRIPTION
I realize this isn't the official extension, but I'm not sure if the official one got taken over?

https://addons.mozilla.org/en-US/firefox/addon/livereload/ says the author is "RIKVIP-Cổng Game Bài Đổi Thưởng Chính Thức", which Google Translate says "RIKVIP - Official Card Game Exchange Portal", which doesn't inspire confidence.